### PR TITLE
Refactor `produce` into a functional one-liner

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,8 +41,4 @@ const getRandomChar = stack => {
   return stack.charAt(getRandomNumber(0, stack.length - 1));
 };
 
-const produce = (number, callback) => {
-  const result = [];
-  for (let index = 0; index < number; index++) result.push(callback(index));
-  return result.join("");
-};
+const produce = (n, fill) => [...Array(n).keys()].map(fill).join("");


### PR DESCRIPTION
Size-limit:   ~~346 B~~ 335 B (-11 B)
`[...Array(n).keys()]` generates an array of `[0,1,2,3...]`

The function now looks a bit cryptic, but I would add a comment above to explain what it does:
"Generates a string of N characters produced with a generator callback"?