### PR TITLE
Improve performance of the `random` and `produce` functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 A tiny memorable password generator
 
-- **Fast**: 16 times faster than `password-generator`
-- **Small**: 342 bytes (minified and gzipped)
+- **Fast**: 600 times faster than `password-generator`
+- **Small**: 334 bytes (minified and gzipped)
 - **Safe**: Uses [cryptographically strong random API](https://nodejs.org/api/crypto.html) instead of `Math.random`
 - **No dependencies**
 - Supports Node.js and browsers

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const random = require("./random");
+const getRandomValues = require("./random");
 
 module.exports = (options = {}) => {
   return getRandomPassword({
@@ -45,4 +45,17 @@ const produce = (number, callback) => {
   const result = [];
   for (let index = 0; index < number; index++) result.push(callback(index));
   return result.join("");
+};
+
+let buffer = [];
+let bufferSize = 0xffff;
+let bufferIndex = bufferSize + 1;
+
+const random = limit => {
+  if (++bufferIndex > bufferSize) {
+    buffer = getRandomValues(bufferSize);
+    bufferIndex = 0;
+  }
+
+  return buffer[bufferIndex] % limit;
 };

--- a/index.js
+++ b/index.js
@@ -42,9 +42,9 @@ const getRandomChar = stack => {
 };
 
 const produce = (number, callback) => {
-  const result = [];
-  for (let index = 0; index < number; index++) result.push(callback(index));
-  return result.join("");
+  let result = "";
+  for (let index = 0; index < number; index++) result += callback(index);
+  return result;
 };
 
 let buffer = [];

--- a/index.js
+++ b/index.js
@@ -37,25 +37,25 @@ const getRandomSyllable = ({
   return syllable;
 };
 
-const getRandomChar = stack => {
-  return stack.charAt(random(stack.length));
-};
+const getRandomChar = stack => stack[random(stack.length)];
 
 const produce = (number, callback) => {
-  let result = "";
-  for (let index = 0; index < number; index++) result += callback(index);
+  for (var index = 0, result = ""; index < number; index++) {
+    result += callback(index);
+  }
+
   return result;
 };
 
 let buffer = [];
 let bufferSize = 0xffff;
-let bufferIndex = bufferSize + 1;
+let bufferIndex = bufferSize;
 
 const random = limit => {
-  if (++bufferIndex > bufferSize) {
+  if (bufferIndex >= bufferSize) {
     buffer = getRandomValues(bufferSize);
     bufferIndex = 0;
   }
 
-  return buffer[bufferIndex] % limit;
+  return buffer[bufferIndex++] % limit;
 };

--- a/random.browser.js
+++ b/random.browser.js
@@ -1,7 +1,13 @@
-const crypto = self.crypto || self.msCrypto;
+let crypto = self.crypto || self.msCrypto;
+let size = 0xffff;
+let index = size + 1;
+let buffer = [];
 
 module.exports = limit => {
-  if (crypto) return crypto.getRandomValues(new Uint8Array(1))[0] % limit;
+  if (++index > size) {
+    buffer = crypto.getRandomValues(new Uint8Array(size));
+    index = 0;
+  }
 
-  return Math.round(Math.random() * 0xffff) % limit;
+  return buffer[index] % limit;
 };

--- a/random.browser.js
+++ b/random.browser.js
@@ -1,13 +1,3 @@
 let crypto = self.crypto || self.msCrypto;
-let size = 0xffff;
-let index = size + 1;
-let buffer = [];
 
-module.exports = limit => {
-  if (++index > size) {
-    buffer = crypto.getRandomValues(new Uint8Array(size));
-    index = 0;
-  }
-
-  return buffer[index] % limit;
-};
+module.exports = size => crypto.getRandomValues(new Uint8Array(size));

--- a/random.js
+++ b/random.js
@@ -5,7 +5,7 @@ let buffer = [];
 
 module.exports = limit => {
   if (++index > size) {
-    buffer = crypto.randomFillSync(new Uint8Array(size));
+    buffer = crypto.randomBytes(size);
     index = 0;
   }
 

--- a/random.js
+++ b/random.js
@@ -1,3 +1,13 @@
-const crypto = require("crypto");
+let crypto = require("crypto");
+let size = 0xffff;
+let index = size + 1;
+let buffer = [];
 
-module.exports = limit => crypto.randomBytes(1).readUInt8() % limit;
+module.exports = limit => {
+  if (++index > size) {
+    buffer = crypto.randomFillSync(new Uint8Array(size));
+    index = 0;
+  }
+
+  return buffer[index] % limit;
+};

--- a/random.js
+++ b/random.js
@@ -1,13 +1,3 @@
 let crypto = require("crypto");
-let size = 0xffff;
-let index = size + 1;
-let buffer = [];
 
-module.exports = limit => {
-  if (++index > size) {
-    buffer = crypto.randomBytes(size);
-    index = 0;
-  }
-
-  return buffer[index] % limit;
-};
+module.exports = size => crypto.randomBytes(size);

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -11,7 +11,7 @@ const libraries = [
     name: "omgopass",
     browser: true,
     node: true,
-    size: 342,
+    size: 334,
     generate: () => omgopass()
   },
   {


### PR DESCRIPTION
Part of #7 

### Changes

1) Get random values from buffers
2) Optimize `produce` function (works with literals instead of arrays)
3) I decided to get rid of `Math.random` fallback. Browser support [is really good](https://caniuse.com/#feat=cryptography) so it doesn't make sense to have it. Popular password and ID generators (such as `nanoid`) don't use a fallback.

### The results are amazing:
```yml
Before:    25 329 ops/sec
After:  1 188 044 ops/sec
```

**47 times faster than before 🎉**

The results are almost equal to `generate-password` (most popular NPM's password generator) which generates not memorable passwords, doesn't work in browsers and has 2x size bundle. **So I guess that's a win!**

I think we can do more, but probably better to do that in a separate PR.

### Full benchmark:
```
┌─────────┬──────────────────────┬─────────┬──────────────┬─────────┬──────┐
│ (index) │         name         │ ops/sec │ size (bytes) │ browser │ node │
├─────────┼──────────────────────┼─────────┼──────────────┼─────────┼──────┤
│    0    │      'omgopass'      │ 1188044 │     342      │  true   │ true │
│    1    │ 'password-generator' │    2274 │     644      │  true   │ true │
│    2    │ 'generate-password'  │ 1209650 │     740      │  false  │ true │
│    3    │      'niceware'      │  316248 │    195584    │  true   │ true │
└─────────┴──────────────────────┴─────────┴──────────────┴─────────┴──────┘
```