### PR TITLE
Separators

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A tiny memorable password generator
 
 - **Fast**: [600 times](#benchmark) faster than `password-generator`
-- **Small**: 294 bytes (minified and gzipped)
+- **Small**: 322 bytes (minified and gzipped)
 - **Secure**: Uses [cryptographically strong random API](https://nodejs.org/api/crypto.html) instead of `Math.random`
 - **No dependencies**
 - Supports Node.js and browsers
@@ -32,11 +32,11 @@ const password = generatePassword(); // Tu6Log5Bam4
 #### Advanced Usage
 
 ```js
-generatePassword({ hasNumbers: false }); // MunBedKod
+generatePassword({ hasNumbers: false }); // "MunBedKod"
 
-generatePassword({ syllablesCount: 5 }); // Rot2Ba5Vim1My8Red4
+generatePassword({ syllablesCount: 5 }); // "Rot2Ba5Vim1My8Red4"
 
-generatePassword({ titlecased: false }); // si5co3ve8
+generatePassword({ titlecased: false }); // "si5co3ve8"
 
 generatePassword({
   syllablesCount: 4,
@@ -44,28 +44,44 @@ generatePassword({
   maxSyllableLength: 4,
   hasNumbers: false,
   titlecased: true,
+  separators: "-_",
   vowels: "аеиоуэюя",
   consonants: "бвгджзклмнпрстчш"
-}); // ЗерКотиЛовМеч
+}); // "Зер_Коти-Лов_Меч"
+```
+
+#### Recipe: Generate random passphrase
+
+Looking for long passwords that are easy to remember but hard to guess? Try to generate random passphrase instead.
+
+```js
+generatePassword({
+  minSyllableLength: 4,
+  maxSyllableLength: 6,
+  hasNumbers: false,
+  titlecased: false,
+  separators: " "
+}); // "goferu lipeba cyzex"
 ```
 
 #### Available options
 
-| Name                | Description                           | Default              |
-| ------------------- | ------------------------------------- | -------------------- |
-| `syllablesCount`    | Integer, count of syllables           | `3`                  |
-| `minSyllableLength` | Integer, minimal length of a syllable | `2`                  |
-| `maxSyllableLength` | Integer, max length of a syllable     | `3`                  |
-| `hasNumbers`        | Boolean, put numbers in the password  | `true`               |
-| `titlecased`        | Boolean, use titlecase                | `true`               |
-| `vowels`            | String, vowel alphabet                | `'aeiouy'`           |
-| `consonants`        | String, consonant alphabet            | `'bcdfghklmnprstvz'` |
+| Name                | Description                             | Default              |
+| ------------------- | --------------------------------------- | -------------------- |
+| `syllablesCount`    | Integer, count of syllables             | `3`                  |
+| `minSyllableLength` | Integer, minimal length of a syllable   | `2`                  |
+| `maxSyllableLength` | Integer, max length of a syllable       | `3`                  |
+| `hasNumbers`        | Boolean, put numbers in the password    | `true`               |
+| `titlecased`        | Boolean, use titlecase                  | `true`               |
+| `vowels`            | String, vowel alphabet                  | `'aeiouy'`           |
+| `consonants`        | String, consonant alphabet              | `'bcdfghklmnprstvz'` |
+| `separators`        | String, symbols that separate syllables | `''`                 |
 
 ### Benchmark
 
 | name                   | ops/sec       | size (bytes) | memorable | browser | node |
 | ---------------------- | ------------- | ------------ | --------- | ------- | ---- |
-| omgopass               | **1 430 233** | **294**      | true      | true    | true |
+| omgopass               | **1 430 233** | **322**      | true      | true    | true |
 | password-generator     | 2 163         | 644          | true      | true    | true |
 | generate-password      | 696 006       | 740          | false     | false   | true |
 | randomatic             | 29 796        | 1 740        | false     | true    | true |

--- a/index.js
+++ b/index.js
@@ -6,10 +6,11 @@ module.exports = ({
   maxSyllableLength = 3,
   hasNumbers = true,
   titlecased = true,
+  separators = "",
   vowels = "aeiouy",
   consonants = "bcdfghjklmnpqrstvwxz"
 } = {}) =>
-  produce(syllablesCount, () => {
+  produce(syllablesCount, i => {
     let length =
       minSyllableLength + random(maxSyllableLength - minSyllableLength + 1);
 
@@ -20,7 +21,11 @@ module.exports = ({
       return titlecased && !index ? char.toUpperCase() : char;
     });
 
-    return hasNumbers ? syllable + random(10) : syllable;
+    if (hasNumbers) syllable += random(10);
+
+    return i && separators
+      ? separators[random(separators.length)] + syllable
+      : syllable;
   });
 
 let produce = (number, callback) => {

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -15,7 +15,7 @@ const libraries = [
     memorable: true,
     browser: true,
     node: true,
-    size: 294,
+    size: 322,
     generate: () => omgopass()
   },
   {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -64,19 +64,18 @@ test("change characters", () => {
 
 test("enable separators", () => {
   const password = generatePassword({ separators: "<>" });
-  const regexp = /^([A-Z][a-z]{1,2}[0-9][<>]){2}[A-Z][a-z]{1,2}[0-9]/;
-  expect(regexp.test(password)).toBe(true);
+  expect(password.split(/[<>]/)).toHaveLength(3);
 });
 
 test("generate passphrase", () => {
+  const syllablesCount = 4;
   const password = generatePassword({
+    syllablesCount,
     minSyllableLength: 4,
     maxSyllableLength: 6,
     hasNumbers: false,
     titlecased: false,
     separators: " "
   });
-  const regexp = /^[a-z]{4,6} [a-z]{4,6} [a-z]{4,6}$/;
-  console.log(password);
-  expect(regexp.test(password)).toBe(true);
+  expect(password.split(" ")).toHaveLength(syllablesCount);
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -61,3 +61,21 @@ test("change characters", () => {
   const regexp = /^([А-Я][а-я]{1,2}[0-9]){3}/;
   expect(regexp.test(password)).toBe(true);
 });
+
+test("enable separators", () => {
+  const password = generatePassword({ separators: "<>" });
+  const regexp = /^([A-Z][a-z]{1,2}[0-9][<>]){2}[A-Z][a-z]{1,2}[0-9]/;
+  expect(regexp.test(password)).toBe(true);
+});
+
+test("generate passphrase", () => {
+  const password = generatePassword({
+    minSyllableLength: 4,
+    maxSyllableLength: 6,
+    hasNumbers: false,
+    titlecased: false,
+    separators: " "
+  });
+  const regexp = /^[a-z]{4,6} [a-z]{4,6} [a-z]{4,6}$/;
+  expect(regexp.test(password)).toBe(true);
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -77,5 +77,6 @@ test("generate passphrase", () => {
     separators: " "
   });
   const regexp = /^[a-z]{4,6} [a-z]{4,6} [a-z]{4,6}$/;
+  console.log(password);
   expect(regexp.test(password)).toBe(true);
 });


### PR DESCRIPTION
Closes #13

New `separators` option. 

1) Useful for passwords that need special symbols (`separators: "$=_-@"`).
2) Useful to generate passphrases (`separators: " "`).