### PR TITLE
Add Password Pusher to "Who uses ..."

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ Benchmark results were generated on a MBP 2018, 2,3 GHz Intel Core i5. To perfor
 ### Who uses omgopass
 
 - [LogChimp](https://github.com/logchimp/logchimp) — self-hosted platform for products makers to get feedback from their users
-- [Laravel VPN Admin](https://github.com/Laravel-VPN-Admin/api-core) — Admin panel for VPN servers management 
+- [Laravel VPN Admin](https://github.com/Laravel-VPN-Admin/api-core) — Admin panel for VPN servers management
+- [Password Pusher](https://github.com/pglombardo/PasswordPusher) - application to securely communicate passwords over the web
 
 ### Supporting IE11 and obsolete platforms
 


### PR DESCRIPTION
Thank you and my complements on the helpful library you have here.  I've added it to [Password Pusher](https://pwpush.com) and am very happy with the result.

![Screen Shot 2021-08-28 at 15 22 59](https://user-images.githubusercontent.com/395132/131264538-83a61f79-a38f-43c1-b4ff-6555ecb79bf7.png)

In this PR, I've added Password Pusher to the list of "Who uses..." if you care to merge this.

Thanks again.